### PR TITLE
better check process.env in CurrentEcsVersion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,9 @@ export const CurrentEcsVersion = (): EcsVersion => {
 	const { ECS_CONTAINER_METADATA_URI, ECS_CONTAINER_METADATA_URI_V4 } = process.env;
 
 	switch (true) {
-		case ECS_CONTAINER_METADATA_URI_V4 !== "":
+		case !!ECS_CONTAINER_METADATA_URI_V4:
 			return EcsVersion.V4;
-		case ECS_CONTAINER_METADATA_URI !== "":
+		case !!ECS_CONTAINER_METADATA_URI:
 			return EcsVersion.V3;
 		default:
 			throw new Error(`cannot determine ecs instance version`);


### PR DESCRIPTION
Resolve an issue with `index.ts#CurrentEcsVersion` always returning v4.

Current there's a bug where we check `process.env.ECS_CONTAINER_METADATA_URI_V4 !== ""` to see if they are empty strings. However undefined `process.env` variables show up as `undefined` (not `""`). This mismatch causes `v4` is always chosen.

This PR resolves, by using a liberal check: truthiness.