### PR TITLE
Better check process.env in CurrentEcsVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ v4().then((res) => {
 });
 ```
 
+An `aws-ecs-metadata-node` bin is also provided, which will log the discovered metadata as JSON.
+
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A tool to retrieve AWS ECS Task metadata",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "bin": "./lib/bin.js",
   "repository": "https://github.com/AienTech/aws-ecs-metadata-node",
   "author": "Aien Saidi",
   "license": "MIT",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { CurrentFetchMetaData } from "./index";
+
+(async () => {
+	console.log(JSON.stringify(await CurrentFetchMetaData()));
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,9 @@ export const CurrentEcsVersion = (): EcsVersion => {
 	const { ECS_CONTAINER_METADATA_URI, ECS_CONTAINER_METADATA_URI_V4 } = process.env;
 
 	switch (true) {
-		case ECS_CONTAINER_METADATA_URI_V4 !== "":
+		case !!ECS_CONTAINER_METADATA_URI_V4:
 			return EcsVersion.V4;
-		case ECS_CONTAINER_METADATA_URI !== "":
+		case !!ECS_CONTAINER_METADATA_URI:
 			return EcsVersion.V3;
 		default:
 			throw new Error(`cannot determine ecs instance version`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export * as v3 from './v3';
-export * as v4 from './v4';
+import * as v3 from './v3';
+import * as v4 from './v4';
+export { v3, v4 };
 
 export enum EcsVersion {
 	V3 = 'v3',
@@ -17,4 +18,13 @@ export const CurrentEcsVersion = (): EcsVersion => {
 		default:
 			throw new Error(`cannot determine ecs instance version`);
 	}
+};
+
+export const CurrentFetchMetaData = () => {
+	let fn: () => Promise<v3.MetaData | v4.MetaData> = v4.fetchMetaData;
+	switch (CurrentEcsVersion()) {
+		case EcsVersion.V3:
+			fn = v3.fetchMetaData;
+	}
+	return fn();
 };


### PR DESCRIPTION
Resolve an issue with `index.ts#CurrentEcsVersion` always returning v4.

Current there's a bug where we check `process.env.ECS_CONTAINER_METADATA_URI_V4 !== ""` to see if they are empty strings. However undefined `process.env` variables show up as `undefined` (not `""`). This mismatch causes `v4` is always chosen.

This PR resolves, by using a liberal check: truthiness.