### PR TITLE
Simple bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ v4().then((res) => {
 });
 ```
 
+An `aws-ecs-metadata-node` bin is also provided, which will log the discovered metadata as JSON.
+
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A tool to retrieve AWS ECS Task metadata",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "bin": "./lib/bin.js",
   "repository": "https://github.com/AienTech/aws-ecs-metadata-node",
   "author": "Aien Saidi",
   "license": "MIT",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { CurrentFetchMetaData } from "./index";
+
+(async () => {
+	console.log(JSON.stringify(await CurrentFetchMetaData()));
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export * as v3 from './v3';
-export * as v4 from './v4';
+import * as v3 from './v3';
+import * as v4 from './v4';
+export { v3, v4 };
 
 export enum EcsVersion {
 	V3 = 'v3',
@@ -17,4 +18,13 @@ export const CurrentEcsVersion = (): EcsVersion => {
 		default:
 			throw new Error(`cannot determine ecs instance version`);
 	}
+};
+
+export const CurrentFetchMetaData = () => {
+	let fn: () => Promise<v3.MetaData | v4.MetaData> = v4.fetchMetaData;
+	switch (CurrentEcsVersion()) {
+		case EcsVersion.V3:
+			fn = v3.fetchMetaData;
+	}
+	return fn();
 };


### PR DESCRIPTION
Create a simple `package.json#bin` that runs aws-ecs-metadata-node` & outputs the results into JSON.

Admittedly this could well just be a curl script, but this library nicely knows the urls ahead of time & builds on what we've got.

This PR also introduces/exports a `index.ts#CurrentFetchMetaData` (named inline with the file's existing `CurrentEcsVersion` export`) that sensibly chooses the correct metadata endpoint (v3 or v4) & reads data from it, making consuming this library just a bit easier (if you're willing to cope with the varied output formats across v3 and v4).